### PR TITLE
fixing regex to not replace comments

### DIFF
--- a/django_url_prefixer/middleware.py
+++ b/django_url_prefixer/middleware.py
@@ -17,7 +17,7 @@ class URLPrefixer:
         response = self.getResponse(request)
         content = response.content.decode('utf-8')
         content = re.sub(
-            r'(?<!(\/|<|\w|:))((\/)(\w{0,}))',
+            r'(?<!(\/|<|\w|:))(\/(?!\/)(\w*))',
             f'{settings.URL_PREFIX}\\2',
             content,
         )

--- a/django_url_prefixer/middleware.py
+++ b/django_url_prefixer/middleware.py
@@ -17,7 +17,7 @@ class URLPrefixer:
         response = self.getResponse(request)
         content = response.content.decode('utf-8')
         content = re.sub(
-            r'(?<!(\/|<|\w|:))(\/(?!\/)(\w*))',
+            r'(?<!(\/|<|\w|:|>|}))(\/(?!\/)(\w*))',
             f'{settings.URL_PREFIX}\\2',
             content,
         )


### PR DESCRIPTION
when using django_url_prefixer and drf_spectacular_sidecar comments in swaggerui.js are replaced with the prefix which leads to syntax errors